### PR TITLE
I've corrected the script loading to resolve the malfunction on your …

### DIFF
--- a/main.html
+++ b/main.html
@@ -163,6 +163,7 @@
         </div>
     </main>
 
-    <script src="js/main.js"></script>
+    <script src="js/common.js"></script>
+    <script type="module" src="js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
…website.

Your website was failing to load the header and data due to two issues:
1. The `js/common.js` script, which handles header injection, was not being included in `main.html`.
2. The `js/main.js` script uses ES module syntax (`import`/`export`) but was not being loaded with `type="module"`, which caused a fatal JavaScript error that prevented data from loading.

I resolved these problems by:
- Adding a script tag for `js/common.js` to `main.html`.
- Adding the `type="module"` attribute to the script tag for `js/main.js`.