### PR TITLE
fix: Correct Supabase table name for grievance form

### DIFF
--- a/js/grievance.js
+++ b/js/grievance.js
@@ -10,7 +10,7 @@ grievanceForm.addEventListener('submit', async function(e) {
   const description = document.getElementById('grievanceDescription').value;
 
   const { data, error } = await supabase
-    .from('Grievance Redressal')
+    .from('grievance_redressal')
     .insert([
       {
         subject,


### PR DESCRIPTION
The grievance form submission was failing because it was attempting to insert data into a Supabase table named 'Grievance Redressal'.

This commit corrects the table name to 'grievance_redressal', which aligns with the naming convention of other tables in the project and is the likely correct identifier in the database. This change allows the grievance form to submit data to Supabase successfully.