### PR TITLE
fix: add footer and scripts to burger joints page

### DIFF
--- a/burger_joints.html
+++ b/burger_joints.html
@@ -84,5 +84,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                 </div>
             </div>
 
-            <div class="burger-card">
-                <div class="card-image-placeholder" style="
+        </section>
+    </main>
+    <div id="footer-container"></div>
+    <script src="js/auth.js"></script>
+    <script src="js/common.js"></script>
+</body>
+</html>


### PR DESCRIPTION
The burger_joints.html page was missing the footer and the header was not appearing. This was because the page was missing the footer container div and the common javascript files were not being included.

This change adds the footer container and the necessary script tags to the page, which will allow the header and footer to be loaded correctly.